### PR TITLE
Remove non-existent provider from META-INF/services

### DIFF
--- a/src/META-INF/services/org.apache.xalan.extensions.bsf.BSFManager
+++ b/src/META-INF/services/org.apache.xalan.extensions.bsf.BSFManager
@@ -1,1 +1,0 @@
-org.apache.bsf.BSFManager


### PR DESCRIPTION
org.apache.bsf.BSFManager is not available from this Jar file.